### PR TITLE
Change to non-expiring tbl2asn frozen to v25.7.1

### DIFF
--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -2,6 +2,6 @@ mafft=7.402
 mummer4=4.0.0beta2
 muscle=3.8.1551 
 snpeff=4.3.1t
-tbl2asn=25.6
+tbl2asn-forever=25.7.1f
 vphaser2=2.0
 # Python packages below


### PR DESCRIPTION
The most recent version of tbl2asn (v25.8) is not currently compatible with bioconda, however  v25.7.1 from Jan 2019 is available with a wrapper to deceive the date check as the package `tbl2asn-forever`.
See: https://github.com/bioconda/bioconda-recipes/pull/20073