### PR TITLE
simplify fasta naming for one-chr genomes

### DIFF
--- a/ncbi.py
+++ b/ncbi.py
@@ -618,9 +618,13 @@ def prep_genbank_files(templateFile, fasta_files, annotDir,
         # for each segment/chromosome in the fasta file,
         # create a separate new *.fsa file
         with open(fn, "r") as inf:
+            n_segs = len(list(1 for s in Bio.SeqIO.parse(inf, 'fasta')))
             asm_fasta = Bio.SeqIO.parse(inf, 'fasta')
             for idx, seq_obj in enumerate(asm_fasta):
-                sample = sample_base + "-" + str(idx+1)
+                if n_segs>1:
+                    sample = sample_base + "-" + str(idx+1)
+                else:
+                    sample = sample_base
 
                 # write the segment to a temp .fasta file
                 # in the same dir so fasta2fsa functions as expected
@@ -648,7 +652,7 @@ def prep_genbank_files(templateFile, fasta_files, annotDir,
                 # make .cmt files
                 make_structured_comment_file(os.path.join(annotDir, sample + '.cmt'),
                                              name=sample,
-                                             coverage=coverage.get(sample),
+                                             coverage=coverage.get(sample, coverage.get(sample_base)),
                                              seq_tech=sequencing_tech,
                                              assembly_method=assembly_method,
                                              assembly_method_version=assembly_method_version)

--- a/ncbi.py
+++ b/ncbi.py
@@ -618,9 +618,13 @@ def prep_genbank_files(templateFile, fasta_files, annotDir,
         # for each segment/chromosome in the fasta file,
         # create a separate new *.fsa file
         with open(fn, "r") as inf:
+            n_segs = len(list(1 for s in Bio.SeqIO.parse(inf, 'fasta')))
             asm_fasta = Bio.SeqIO.parse(inf, 'fasta')
             for idx, seq_obj in enumerate(asm_fasta):
-                sample = sample_base + "-" + str(idx+1)
+                if n_segs>1:
+                    sample = sample_base + "-" + str(idx+1)
+                else:
+                    sample = sample_base
 
                 # write the segment to a temp .fasta file
                 # in the same dir so fasta2fsa functions as expected

--- a/ncbi.py
+++ b/ncbi.py
@@ -628,14 +628,12 @@ def prep_genbank_files(templateFile, fasta_files, annotDir,
 
                 # write the segment to a temp .fasta file
                 # in the same dir so fasta2fsa functions as expected
-                out_file_name = os.path.join(os.path.dirname(fn),sample+".fasta")
-                with open(out_file_name, "w") as out_chr_fasta:
-                    Bio.SeqIO.write(seq_obj, out_chr_fasta, "fasta")
-
-                # make .fsa files
-                fasta2fsa(out_file_name, annotDir, biosample=biosample.get(sample_base))
-                # remove the .fasta file
-                os.unlink(out_file_name)
+                with util.file.tmp_dir() as tdir:
+                    temp_fasta_fname = os.path.join(tdir,sample+".fasta")
+                    with open(temp_fasta_fname, "w") as out_chr_fasta:
+                        Bio.SeqIO.write(seq_obj, out_chr_fasta, "fasta")
+                    # make .fsa files
+                    fasta2fsa(temp_fasta_fname, annotDir, biosample=biosample.get(sample_base))
 
                 # make .src files
                 if master_source_table:

--- a/ncbi.py
+++ b/ncbi.py
@@ -617,8 +617,8 @@ def prep_genbank_files(templateFile, fasta_files, annotDir,
 
         # for each segment/chromosome in the fasta file,
         # create a separate new *.fsa file
+        n_segs = util.file.fasta_length(fn)
         with open(fn, "r") as inf:
-            n_segs = len(list(1 for s in Bio.SeqIO.parse(inf, 'fasta')))
             asm_fasta = Bio.SeqIO.parse(inf, 'fasta')
             for idx, seq_obj in enumerate(asm_fasta):
                 if n_segs>1:

--- a/ncbi.py
+++ b/ncbi.py
@@ -618,13 +618,9 @@ def prep_genbank_files(templateFile, fasta_files, annotDir,
         # for each segment/chromosome in the fasta file,
         # create a separate new *.fsa file
         with open(fn, "r") as inf:
-            n_segs = len(list(1 for s in Bio.SeqIO.parse(inf, 'fasta')))
             asm_fasta = Bio.SeqIO.parse(inf, 'fasta')
             for idx, seq_obj in enumerate(asm_fasta):
-                if n_segs>1:
-                    sample = sample_base + "-" + str(idx+1)
-                else:
-                    sample = sample_base
+                sample = sample_base + "-" + str(idx+1)
 
                 # write the segment to a temp .fasta file
                 # in the same dir so fasta2fsa functions as expected


### PR DESCRIPTION
Stop appending `-1` suffix to genbank submissions for 1-segment genomes