### PR TITLE
rollback viral-core to 2.1.9 for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-core:2.1.10
+FROM quay.io/broadinstitute/viral-core:2.1.9
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 


### PR DESCRIPTION
pending dependency resolution upstream