### PR TITLE
ncbi file prep updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-core:2.1.12
+FROM quay.io/broadinstitute/viral-core:2.1.13
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 


### PR DESCRIPTION
- bump viral-core to 2.1.13
- add optional scripts to output files for bulk programmatic/ftp submission to genbank via [this mechanism](https://www.ncbi.nlm.nih.gov/viewvc/v1/trunk/submit/public-docs/genbank/SARS-CoV-2/) (note this only works for a handful of viral species at the moment, but it's basically submitting the inputs to VADR and tbl2asn and not having to actually run them)