### PR TITLE
Fix: Add support for DDBJ accession prefix (dbj|)

### DIFF
--- a/phylo/feature_table.py
+++ b/phylo/feature_table.py
@@ -142,7 +142,7 @@ class FeatureTable(object):
         self.valid_feature_types = valid_feature_types or self._default_feature_types
 
         self.feature_line_regex_map = {        
-            "feature_table_header"             : re.compile(r"^>Feature (gb\||ref\||emb\|)(?P<refID>.*)\|.*$"),
+            "feature_table_header"             : re.compile(r"^>Feature (gb\||ref\||emb\||dbj\|)(?P<refID>.*)\|.*$"),
             "feature_first_location_line"      : re.compile(r"^(?P<location_operator_start>[<>])?(?P<start>\d+)\t(?P<location_operator_end>[<>])?(?P<end>\d+)\t(?P<feature_type>" + "|".join(self.valid_feature_types) + ")$"),
             "feature_subsequent_location_line" : re.compile(r"^(?P<location_operator_start>[<>])?(?P<start>\d+)\t(?P<location_operator_end>[<>])?(?P<end>\d+)\t*$"),
             "offset_line"                      : re.compile(r"^(?:\[offset=(?P<offset>-?\d+)\])$"),

--- a/phylo/genbank.py
+++ b/phylo/genbank.py
@@ -34,9 +34,9 @@ def get_feature_table_id(featureTableFile):
                     raise Exception("not sure how to handle a non-Feature record")
                 seqid = line[len('>Feature '):].strip()
                 if not (
-                    (seqid.startswith('gb|') or seqid.startswith('ref|'))):
-                    raise Exception("reference annotation ID does not appear to refer to a GenBank or RefSeq accession: %s" % seqid)
-                m = re.search(r"(?P<db>(?:gb|ref|dbj))\|(?:(?P<accession>[a-zA-Z0-9\._]+))+.*", seqid)
+                    (seqid.startswith('gb|') or seqid.startswith('ref|') or seqid.startswith('emb|') or seqid.startswith('dbj|'))):
+                    raise Exception("reference annotation ID does not appear to refer to a GenBank, RefSeq, EMBL, or DDBJ accession: %s" % seqid)
+                m = re.search(r"(?P<db>(?:gb|ref|emb|dbj))\|(?:(?P<accession>[a-zA-Z0-9\._]+))+.*", seqid)
                 if m:
                    seqid = m.group("accession")
                 else:

--- a/test/input/TestFeatureReader/LC889323.1.tbl
+++ b/test/input/TestFeatureReader/LC889323.1.tbl
@@ -1,0 +1,8 @@
+>Feature dbj|LC889323.1|
+1	2280	gene
+			gene	test_gene
+			locus_tag	TEST_gp1
+1	2280	CDS
+			product	test protein
+			protein_id	dbj|TEST123.1|
+

--- a/test/unit/test_ncbi.py
+++ b/test/unit/test_ncbi.py
@@ -43,6 +43,10 @@ class TestFeatureReader(TestCaseWithTmp):
         self.assertEqual('NC_026438.1', phylo.genbank.get_feature_table_id(os.path.join(self.input_dir,
             'NC_026438.1.tbl')))
 
+    def test_read_seq_id_ddbj(self):
+        self.assertEqual('LC889323.1', phylo.genbank.get_feature_table_id(os.path.join(self.input_dir,
+            'LC889323.1.tbl')))
+
 class TestFeatureTransfer(TestCaseWithTmp):
     def setUp(self):
         super(TestFeatureTransfer, self).setUp()


### PR DESCRIPTION
## Summary
- Fixes #65: Feature table parser now supports DDBJ accessions with `dbj|` prefix
- Adds `dbj|` to feature table header regex in phylo/feature_table.py
- Fixes inconsistency in phylo/genbank.py validation (adds both `dbj|` and `emb|`)
- Includes test case with DDBJ accession LC889323.1

## Changes
1. **phylo/feature_table.py line 145**: Added `dbj|` to regex alternation
2. **phylo/genbank.py lines 36-38**: Added `dbj|` and `emb|` to validation check
3. **phylo/genbank.py line 39**: Added `emb|` to extraction regex for consistency
4. **test/unit/test_ncbi.py**: Added test_read_seq_id_ddbj test case
5. **test/input/TestFeatureReader/LC889323.1.tbl**: New test data file

## Test Plan
- [x] New test passes: test_read_seq_id_ddbj
- [x] All existing TestFeatureReader tests still pass
- [x] All ncbi unit tests pass

## Background
DDBJ is one of the three major DNA databases (along with GenBank and EMBL)
that comprise the International Nucleotide Sequence Database Collaboration.
The code already had partial support (extraction regex included dbj), but
validation was rejecting these accessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)