### PR TITLE
Fix trailing tabs in feature table continuation lines

### DIFF
--- a/phylo/feature_table.py
+++ b/phylo/feature_table.py
@@ -59,7 +59,12 @@ class SeqLocation(object):
         self.feature_type = feature_type
 
     def __str__(self):
-        return "{start}\t{end}\t{type}".format(start=self.start,end=self.end,type=self.feature_type if self.feature_type else "")
+        if self.feature_type:
+            return "{start}\t{end}\t{type}".format(
+                start=self.start, end=self.end, type=self.feature_type
+            )
+        else:
+            return "{start}\t{end}".format(start=self.start, end=self.end)
 
     def __eq__(self, other):
         return ((self.start, self.end) == (other.start, other.end))

--- a/test/input/TestFeatureTransfer/adenovirus_truncated/expected/mapped.tbl
+++ b/test/input/TestFeatureTransfer/adenovirus_truncated/expected/mapped.tbl
@@ -1,6 +1,6 @@
 >Feature sample
 1740	2010	CDS
-2100	2300	
+2100	2300
 			note	sequencing did not capture all intervals comprising CDS
 			product	multi-interval-protein-with-missing-middle-section
 500	800	CDS

--- a/test/input/TestFeatureTransfer/synthetic/expected/mapped.tbl
+++ b/test/input/TestFeatureTransfer/synthetic/expected/mapped.tbl
@@ -8,8 +8,8 @@
 2740	>1508	gene
 			gene	neg-strand-should-be-present-fuzzy-gt-end
 4000	4027	CDS
-7000	7034	
-7500	7578	
+7000	7034
+7500	7578
 			product	three-ranges-all-output-sorted
 4000	4027	CDS
 			note	sequencing did not capture all intervals comprising CDS

--- a/test/input/TestFeatureTransfer/synthetic_ignore_ambig_edges/expected/mapped.tbl
+++ b/test/input/TestFeatureTransfer/synthetic_ignore_ambig_edges/expected/mapped.tbl
@@ -8,8 +8,8 @@
 2740	1508	gene
 			gene	neg-strand-should-be-present-fuzzy-gt-end
 4000	4027	CDS
-7000	7034	
-7500	7578	
+7000	7034
+7500	7578
 			product	three-ranges-all-output-sorted
 4000	4027	CDS
 			note	sequencing did not capture all intervals comprising CDS

--- a/test/input/TestFeatureTransfer/synthetic_oob_clip/expected/mapped.tbl
+++ b/test/input/TestFeatureTransfer/synthetic_oob_clip/expected/mapped.tbl
@@ -8,11 +8,11 @@
 2740	>1508	gene
 			gene	neg-strand-should-be-present-fuzzy-gt-end
 4000	4027	CDS
-7000	7034	
-7500	7578	
+7000	7034
+7500	7578
 			product	three-ranges-all-output-sorted
 4000	4027	CDS
-7000	>9012	
+7000	>9012
 			note	sequencing did not capture complete CDS
 			product	two-ranges-with-second-truncated-downstream
 5379	5454	CDS


### PR DESCRIPTION
## Summary
- Fixed `SeqLocation.__str__()` to output 2 columns for continuation lines (no trailing tab)
- Updated test validation to correctly detect trailing tabs as invalid
- Added unit test for `SeqLocation.__str__()` format
- Fixed expected output files to match NCBI feature table spec

Fixes #69

## Test plan
- [x] Run `pytest -v test/unit/test_ncbi.py::TestFeatureReader::test_seq_location_str_format`
- [x] Run `pytest -v test/unit/test_ncbi.py::TestFeatureTransfer::test_severely_truncated_assembly_oob_clip`
- [x] Run full unit test suite: `pytest -rsxX -n auto test/unit`

🤖 Generated with [Claude Code](https://claude.ai/code)